### PR TITLE
Fix error that returns false in the authentication

### DIFF
--- a/lib/client/authenticate.js
+++ b/lib/client/authenticate.js
@@ -56,7 +56,7 @@ module.exports = function (log, adldap, clientFactory, options) {
       if (username.toLowerCase().startsWith('cn=') || username.toLowerCase().startsWith('dn=')) {
         log.trace('authenticating via dn')
         try {
-          username= username.replace('dn=','')
+          username = username.replace('dn=', '')
           const authResult = yield auth(username, password)
           return authResult
         } catch (e) {
@@ -84,7 +84,7 @@ module.exports = function (log, adldap, clientFactory, options) {
           if (!user) {
             return false
           }
-          return yield adldap.authenticate('dn='+user.dn, password)
+          return yield adldap.authenticate('dn=' + user.dn, password)
         } catch (e) {
           throw e
         }

--- a/lib/client/authenticate.js
+++ b/lib/client/authenticate.js
@@ -56,6 +56,7 @@ module.exports = function (log, adldap, clientFactory, options) {
       if (username.toLowerCase().startsWith('cn=') || username.toLowerCase().startsWith('dn=')) {
         log.trace('authenticating via dn')
         try {
+          username= username.replace('dn=','')
           const authResult = yield auth(username, password)
           return authResult
         } catch (e) {
@@ -83,7 +84,7 @@ module.exports = function (log, adldap, clientFactory, options) {
           if (!user) {
             return false
           }
-          return yield adldap.authenticate(user.dn, password)
+          return yield adldap.authenticate('dn='+user.dn, password)
         } catch (e) {
           throw e
         }


### PR DESCRIPTION
Fix error that returns **false** in the authentication when **filter** returns Dn that does not start with cn=. For example _"uid = xxx, ou = example"_